### PR TITLE
Implement legacy RFC821 connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ $ composer require genkgo/mail
  
 This library tends to be as compliant with e-mail RFCs as possible. It should be compliant with the following RFCs.
 
+- [RFC 821, Simple Mail Transfer Protocol](https://tools.ietf.org/html/rfc821)
 - [RFC 1896, The text/enriched MIME Content-type](https://tools.ietf.org/html/rfc1896)
 - [RFC 2822, Internet Message Format](https://tools.ietf.org/html/rfc2822)
 - [RFC 2045, Multipurpose Internet Mail Extensions (MIME) Part One](https://tools.ietf.org/html/rfc2045)

--- a/src/Protocol/Smtp/ClientFactory.php
+++ b/src/Protocol/Smtp/ClientFactory.php
@@ -3,15 +3,15 @@ declare(strict_types=1);
 
 namespace Genkgo\Mail\Protocol\Smtp;
 
+use Genkgo\Mail\Protocol\AutomaticConnection;
 use Genkgo\Mail\Protocol\ConnectionInterface;
 use Genkgo\Mail\Protocol\CryptoConstant;
 use Genkgo\Mail\Protocol\PlainTcpConnection;
-use Genkgo\Mail\Protocol\AutomaticConnection;
+use Genkgo\Mail\Protocol\SecureConnection;
 use Genkgo\Mail\Protocol\SecureConnectionOptions;
 use Genkgo\Mail\Protocol\Smtp\Negotiation\AuthNegotiation;
 use Genkgo\Mail\Protocol\Smtp\Negotiation\ForceTlsUpgradeNegotiation;
 use Genkgo\Mail\Protocol\Smtp\Negotiation\TryTlsUpgradeNegotiation;
-use Genkgo\Mail\Protocol\SecureConnection;
 
 /**
  * Class ClientFactory

--- a/src/Protocol/Smtp/Negotiation/TryTlsUpgradeNegotiation.php
+++ b/src/Protocol/Smtp/Negotiation/TryTlsUpgradeNegotiation.php
@@ -8,6 +8,7 @@ use Genkgo\Mail\Protocol\ConnectionInterface;
 use Genkgo\Mail\Protocol\Smtp\Client;
 use Genkgo\Mail\Protocol\Smtp\NegotiationInterface;
 use Genkgo\Mail\Protocol\Smtp\Request\EhloCommand;
+use Genkgo\Mail\Protocol\Smtp\Request\HeloCommand;
 use Genkgo\Mail\Protocol\Smtp\Request\StartTlsCommand;
 use Genkgo\Mail\Protocol\Smtp\Response\EhloResponse;
 
@@ -51,6 +52,9 @@ final class TryTlsUpgradeNegotiation implements NegotiationInterface
     {
         if (empty($this->connection->getMetaData(['crypto']))) {
             $reply = $client->request(new EhloCommand($this->ehlo));
+            if ($reply->isCommandNotImplemented()) {
+                $reply = $client->request(new HeloCommand($this->ehlo));
+            }
             $reply->assertCompleted();
 
             $ehloResponse = new EhloResponse($reply);

--- a/src/Protocol/Smtp/Reply.php
+++ b/src/Protocol/Smtp/Reply.php
@@ -51,6 +51,19 @@ final class Reply
     }
 
     /**
+     * @return bool
+     */
+    public function isCommandNotImplemented(): bool
+    {
+        try {
+            $this->assert(502);
+            return true;
+        } catch (AssertionFailedException $e) {
+            return false;
+        }
+    }
+
+    /**
      * @return array
      */
     public function getMessages(): array

--- a/src/Protocol/Smtp/Request/HeloCommand.php
+++ b/src/Protocol/Smtp/Request/HeloCommand.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Genkgo\Mail\Protocol\Smtp\Request;
+
+use Genkgo\Mail\Protocol\ConnectionInterface;
+use Genkgo\Mail\Protocol\Smtp\RequestInterface;
+
+final class HeloCommand implements RequestInterface
+{
+    /**
+     * @var string
+     */
+    private $hostName;
+
+    /**
+     * HeloCommand constructor.
+     * @param string $hostName
+     */
+    public function __construct($hostName)
+    {
+        $this->hostName = $hostName;
+    }
+
+    /**
+     * @param ConnectionInterface $connection
+     * @return void
+     */
+    public function execute(ConnectionInterface $connection): void
+    {
+        $connection->send(sprintf('HELO %s', $this->hostName));
+    }
+}

--- a/test/Unit/Protocol/Smtp/ClientFactoryTest.php
+++ b/test/Unit/Protocol/Smtp/ClientFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Genkgo\TestMail\Unit\Protocol\Smtp;
 
 use Genkgo\Mail\Exception\ConnectionRefusedException;
+use Genkgo\Mail\Protocol\CryptoConstant;
 use Genkgo\Mail\Protocol\Smtp\Client;
 use Genkgo\Mail\Protocol\Smtp\ClientFactory;
 use Genkgo\Mail\Protocol\Smtp\Request\NoopCommand;
@@ -24,6 +25,7 @@ final class ClientFactoryTest extends AbstractTestCase
         $this->assertNotSame($factory, $factory->withEhlo('127.0.0.1'));
         $this->assertNotSame($factory, $factory->withTimeout(10));
         $this->assertNotSame($factory, $factory->withInsecureConnectionAllowed());
+        $this->assertNotSame($factory, $factory->withStartTls(CryptoConstant::getDefaultMethod(PHP_VERSION)));
     }
 
     /**

--- a/test/Unit/Protocol/Smtp/ReplyTest.php
+++ b/test/Unit/Protocol/Smtp/ReplyTest.php
@@ -86,7 +86,7 @@ final class ReplyTest extends AbstractTestCase
     /**
      * @test
      */
-    public function it_an_error_400()
+    public function it_is_an_error_400()
     {
         $client = new Client(new FakeSmtpConnection());
 
@@ -99,7 +99,7 @@ final class ReplyTest extends AbstractTestCase
     /**
      * @test
      */
-    public function it_an_error_500()
+    public function it_is_an_error_500()
     {
         $client = new Client(new FakeSmtpConnection());
 
@@ -109,4 +109,29 @@ final class ReplyTest extends AbstractTestCase
         $this->assertTrue($reply->isError());
     }
 
+    /**
+     * @test
+     */
+    public function it_is_an_implemented_command()
+    {
+        $client = new Client(new FakeSmtpConnection());
+
+        $reply = (new Reply($client))
+            ->withLine(250, 'Ok');
+
+        $this->assertFalse($reply->isCommandNotImplemented());
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_an_unimplemented_command(): void
+    {
+        $client = new Client(new FakeSmtpConnection());
+
+        $reply = (new Reply($client))
+            ->withLine(502, 'error');
+
+        $this->assertTrue($reply->isCommandNotImplemented());
+    }
 }

--- a/test/Unit/Protocol/Smtp/Request/HeloCommandTest.php
+++ b/test/Unit/Protocol/Smtp/Request/HeloCommandTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Genkgo\TestMail\Unit\Protocol\Smtp\Request;
+
+use Genkgo\Mail\Protocol\ConnectionInterface;
+use Genkgo\Mail\Protocol\Smtp\Request\HeloCommand;
+use Genkgo\TestMail\AbstractTestCase;
+
+final class HeloCommandTest extends AbstractTestCase
+{
+    /**
+     * @test
+     */
+    public function it_executes(): void
+    {
+        $connection = $this->createMock(ConnectionInterface::class);
+
+        $connection
+            ->expects($this->at(0))
+            ->method('send')
+            ->with('HELO host.example.com');
+
+        $command = new HeloCommand('host.example.com');
+        $command->execute($connection);
+    }
+
+}


### PR DESCRIPTION
As per everything with me, feel free to request changes or flat out reject. :+1: 

## Changes:
- Add Protocol\Smtp\Negotiation\TryRfc821UpgradeNegotiation
- Add Protocol\Smtp\Request\HeloCommand
- Add Protocol\Smtp\Reply#isCommandNotImplemented() method
- Add RFC821 "connection allowed" parameter & setter method in ClientFactory
  - Enabled via 'rfc821=true' query parameter in factory string
  - TryRfc821UpgradeNegotiation adds to $negotiators[]
- Unit tests
  - Add HELO response & legacy flag paramter to FakeSmtpConnection
  - Add Protocol\Smtp\Negotiation\TryRfc821UpgradeNegotiationTest
  - Add Protocol\Smtp\Request\HeloCommandTest
  - Test Protocol\Smtp\Reply#isCommandNotImplemented()
  - Test Protocol\Smtp\ClientFactory withRfc821ConnectionAllowed() & newClient() additions

## Use-cases
- Testing, e.g. `python -m smtpd -n -c DebuggingServer localhost:25`
- Legacy lock-in :disappointed: 

## Using

```php
$transport = new SmtpTransport(
    ClientFactory::fromString('smtp://localhost:25?rfc821=true')->newClient(),
    EnvelopeFactory::useExtractedHeader()
);
```