### PR TITLE
Implement PHP-CS-Fixer code style rule-set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor/
 /composer.lock
 /example/config.php
+/.php_cs.cache

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,18 @@
+<?php
+
+if (!file_exists(__DIR__ . '/src')) {
+    exit(0);
+}
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+        '@PHP71Migration:risky' => true,
+        '@PHPUnit60Migration:risky' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'declare_strict_types' => true,
+        'yoda_style' => false,
+    ])
+    ->setRiskyAllowed(true)
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,16 @@ matrix:
     - php: nightly
 before_script:
   - composer self-update
+  # Nightly (unreleased) PHP versions are generally not supported by PHP-CS-Fixer
+  - if [ "$TRAVIS_PHP_VERSION" = "nightly" ]; then composer remove --dev --no-update friendsofphp/php-cs-fixer ; fi
   - if [ -z "$dependencies" ]; then composer install; fi;
   - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest -n; fi;
   - if [ "$dependencies" = "highest" ]; then composer update -n; fi;
-after_script:
-  - vendor/bin/phpunit --coverage-clover=coverage.clover
   - wget https://scrutinizer-ci.com/ocular.phar
+script:
+  - vendor/bin/phpunit --coverage-clover=coverage.clover
+after_script:
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+cache:
+  directories:
+    - $HOME/.composer/cache/files/

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,11 @@
         "ext-intl": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6",
-        "predis/predis": "~1.0",
+        "ext-openssl": "*",
+        "friendsofphp/php-cs-fixer": "^2.9",
         "phpstan/phpstan": "^0.7.0",
-        "ext-openssl": "*"
+        "phpunit/phpunit": "~6",
+        "predis/predis": "~1.0"
     },
     "authors": [
         {
@@ -31,5 +32,11 @@
         "psr-4": {
             "Genkgo\\TestMail\\": ["test"]
         }
+    },
+    "scripts": {
+        "lint": "vendor/bin/php-cs-fixer fix --verbose ."
+    },
+    "scripts-descriptions": {
+        "lint": "Run PHP-CS-Fixer and make changes to comply with code style standards"
     }
 }


### PR DESCRIPTION
## Changes

- Add PHP-CS-Fixer to require-dev
- Add rule-set
- Add script shortcut to composer.json
- Update .travis.yml
  - Remove friendsofphp/php-cs-fixer for nightly builds
  - Move Ocular fetch to before_script
  - Move PHPUnit run to script
  - Cache Composer downloaded files

## Use case

- Allow maintainer and contributors to have a consistent reference point, and automated compliance with, code style and layout

## Usage

As discussed, once fully implemented this will allow a developer to not have to focus at all on code style, while maintaining a consistent base for future contribution.

Fixes to code style can be performed in one of two ways.

As a composer script that runs across all files:
```
composer lint
```

Running directly to update a single file (or directory):
```
vendor/bin/php-cs-fixer fix --verbose src/ClassFile.php
```

## Ruleset

This is the part that almost certainly makes this PR a work in progress.

I have based this on Symfony's standards, as it seemed closest to what was in use now. I have no firm opinion either way, as long as there is a reference point, I'll just run the fixer and comply with what is desired :smile: 

Notable results:

- PSR-2 and PSR-12 compliance
- Closer conformance to [PSR-5](https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc.md) doc blocks
  - Aligned `@param` variables
  - Spaces between `@param` and other PHPDoc elements, etc
- Use of `@packge` is discouraged/dropped
- LF as the last line of files

Points for further discussion:

- Are above results acceptable? See [example branch results](https://github.com/genkgo/mail/compare/master...GawainLynch:hotfix/code-style-updates)

- Unnecessary PHPDoc removal:

PHP 7, and especially post-7.1, remove the need & use of a lot of PHPDoc. For example:

```php
    /**
     * ClientFactory constructor.
     *
     * @param ConnectionInterface $connection
     */
    public function __construct(ConnectionInterface $connection) {}

    /**
     * @param int    $method
     * @param string $password
     * @param string $username
     *
     * @return ClientFactory
     */
    public function withAuthentication(int $method, string $username, string $password): self {}
```

All parameters are type-hinted, and visually and IDE recognisable without PHPDoc. Removing those lowers maintenance overhead on both developers and contributors as the code base grows and evolves.

The obvious exception is where a `mixed` variable is expected, at which point that should be expected to be defined by an `@param` entry. Obviously mixed data variables are highly undesirable anyway, so well maintained code … well, the point should appear :wink: 

**NOTE:** If this is considered desirable, it should be carried out prior to using the CS fixer to create an updated branch.
  