### PR TITLE
SMTP Server: handle unexpected client behaviour

### DIFF
--- a/src/Exception/ConnectionBrokenException.php
+++ b/src/Exception/ConnectionBrokenException.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Genkgo\Mail\Exception;
+
+/**
+ * Class ConnectionBrokenException
+ * @package Genkgo\Mail\Exception
+ */
+final class ConnectionBrokenException extends AbstractProtocolException
+{
+
+}

--- a/src/Exception/ConnectionClosedException.php
+++ b/src/Exception/ConnectionClosedException.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Genkgo\Mail\Exception;
+
+/**
+ * Class ConnectionClosedException
+ * @package Genkgo\Mail\Exception
+ */
+final class ConnectionClosedException extends AbstractProtocolException
+{
+
+}

--- a/src/Protocol/AbstractConnection.php
+++ b/src/Protocol/AbstractConnection.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 namespace Genkgo\Mail\Protocol;
 
 use Genkgo\Mail\Exception\CannotWriteToStreamException;
+use Genkgo\Mail\Exception\ConnectionBrokenException;
 use Genkgo\Mail\Exception\ConnectionTimeoutException;
+use Genkgo\Mail\Exception\ConnectionClosedException;
 
 /**
  * Class AbstractConnection
@@ -112,6 +114,10 @@ abstract class AbstractConnection implements ConnectionInterface
 
         $this->verifyAlive();
 
+        if ($response === false) {
+            throw new ConnectionBrokenException('Cannot receive information');
+        }
+
         return $response;
     }
 
@@ -158,6 +164,10 @@ abstract class AbstractConnection implements ConnectionInterface
         $info = stream_get_meta_data($this->resource);
         if ($info['timed_out']) {
             throw new ConnectionTimeoutException('Connection has timed out');
+        }
+
+        if ($info['eof']) {
+            throw new ConnectionClosedException('Connection is gone');
         }
     }
 }

--- a/src/Protocol/Smtp/Server.php
+++ b/src/Protocol/Smtp/Server.php
@@ -59,33 +59,46 @@ final class Server
             $connection = new TrimCrlfConnection(new AppendCrlfConnection($connection));
             $connection->send('220 Welcome to Genkgo Mail Server');
 
+            $this->transport(
+                $connection,
+                function (ConnectionInterface $connection) {
+                    $session = new Session();
+
+                    while ($session = $session->withCommand($connection->receive())) {
+                        try {
+                            $session = $this->handleCommand($connection, $session);
+                        } catch (UnknownSmtpCommandException $e) {
+                            $connection->send('500 unrecognized command');
+                        }
+
+                        if ($session->getState() === Session::STATE_DISCONNECT) {
+                            break;
+                        }
+                    }
+                }
+            );
+        }
+    }
+
+    /**
+     * @param ConnectionInterface $connection
+     * @param \Closure $callback
+     */
+    private function transport(ConnectionInterface $connection, \Closure $callback) {
+        try {
+            $callback($connection);
+        } catch (ConnectionTimeoutException $e) {
+            $connection->send('421 command timeout - closing connection');
+            $connection->disconnect();
+        } catch (ConnectionBrokenException $e) {
             try {
-                $session = new Session();
-
-                while ($session = $session->withCommand($connection->receive())) {
-                    try {
-                        $session = $this->handleCommand($connection, $session);
-                    } catch (UnknownSmtpCommandException $e) {
-                        $connection->send('500 unrecognized command');
-                    }
-
-                    if ($session->getState() === Session::STATE_DISCONNECT) {
-                        break;
-                    }
-                }
-            } catch (ConnectionTimeoutException $e) {
-                $connection->send('421 command timeout - closing connection');
-                $connection->disconnect();
-            } catch (ConnectionBrokenException $e) {
-                try {
-                    $connection->send('554 transaction failed, unexpected value - closing connection');
-                } catch (\Exception $e) {
-                }
-
-                $connection->disconnect();
-            } catch (ConnectionClosedException $e) {
-                $connection->disconnect();
+                $connection->send('554 transaction failed, unexpected value - closing connection');
+            } catch (\Exception $e) {
             }
+
+            $connection->disconnect();
+        } catch (ConnectionClosedException $e) {
+            $connection->disconnect();
         }
     }
 


### PR DESCRIPTION
- fix server crash when client closes connection
- also handle the possible event that connection->receive returns false (broken connections)

Fixes #34.