### PR TITLE
fix tls negotation for RFC 821 servers

### DIFF
--- a/src/Protocol/Smtp/Negotiation/ForceTlsUpgradeNegotiation.php
+++ b/src/Protocol/Smtp/Negotiation/ForceTlsUpgradeNegotiation.php
@@ -3,11 +3,13 @@ declare(strict_types=1);
 
 namespace Genkgo\Mail\Protocol\Smtp\Negotiation;
 
+use Genkgo\Mail\Exception\AssertionFailedException;
 use Genkgo\Mail\Exception\ConnectionInsecureException;
 use Genkgo\Mail\Protocol\ConnectionInterface;
 use Genkgo\Mail\Protocol\Smtp\Client;
 use Genkgo\Mail\Protocol\Smtp\NegotiationInterface;
 use Genkgo\Mail\Protocol\Smtp\Request\EhloCommand;
+use Genkgo\Mail\Protocol\Smtp\Request\HeloCommand;
 use Genkgo\Mail\Protocol\Smtp\Request\StartTlsCommand;
 use Genkgo\Mail\Protocol\Smtp\Response\EhloResponse;
 
@@ -49,12 +51,31 @@ final class ForceTlsUpgradeNegotiation implements NegotiationInterface
      */
     public function negotiate(Client $client): void
     {
-        if (empty($this->connection->getMetaData(['crypto']))) {
-            $reply = $client->request(new EhloCommand($this->ehlo));
+        if (!empty($this->connection->getMetaData(['crypto']))) {
+            return;
+        }
+
+        $reply = $client->request(new EhloCommand($this->ehlo));
+
+        if ($reply->isCommandNotImplemented()) {
+            $reply = $client->request(new HeloCommand($this->ehlo));
+            $reply->assertCompleted();
+
+            try {
+                $client
+                    ->request(new StartTlsCommand())
+                    ->assertCompleted();
+
+                $this->connection->upgrade($this->crypto);
+            } catch (AssertionFailedException $e) {
+                throw new ConnectionInsecureException(
+                    'Server does not support STARTTLS. Use smtps:// or to allow insecure connections use smtp-starttls://'
+                );
+            }
+        } else {
             $reply->assertCompleted();
 
             $ehloResponse = new EhloResponse($reply);
-
             if ($ehloResponse->isAdvertising('STARTTLS')) {
                 $client
                     ->request(new StartTlsCommand())

--- a/test/Stub/FakeSmtpConnection.php
+++ b/test/Stub/FakeSmtpConnection.php
@@ -70,7 +70,7 @@ final class FakeSmtpConnection implements ConnectionInterface
     }
 
     /**
-     * @param bool $isLegacy
+     * @return FakeSmtpConnection
      */
     public static function newLegacyRfc821(): self
     {

--- a/test/Unit/Protocol/Smtp/Negotiation/ForceTlsUpgradeNegotiationTest.php
+++ b/test/Unit/Protocol/Smtp/Negotiation/ForceTlsUpgradeNegotiationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Genkgo\TestMail\Unit\Protocol\Smtp\Negotiation;
 
 use Genkgo\Mail\Exception\ConnectionInsecureException;
+use Genkgo\Mail\Protocol\ConnectionInterface;
 use Genkgo\Mail\Protocol\CryptoConstant;
 use Genkgo\Mail\Protocol\Smtp\Client;
 use Genkgo\Mail\Protocol\Smtp\Negotiation\ForceTlsUpgradeNegotiation;
@@ -40,6 +41,107 @@ final class ForceTlsUpgradeNegotiationTest extends AbstractTestCase
 
         $connection = new FakeSmtpConnection(['250 AUTH PLAIN']);
         $connection->connect();
+
+        $negotiator = new ForceTlsUpgradeNegotiation(
+            $connection,
+            'hostname',
+            CryptoConstant::getDefaultMethod(PHP_VERSION)
+        );
+        $negotiator->negotiate(new Client($connection));
+    }
+
+    /**
+     * @test
+     */
+    public function it_uses_legacy_rfc821_helo_when_ehlo_not_supported()
+    {
+        $connection = FakeSmtpConnection::newLegacyRfc821();
+        $connection->connect();
+
+        $negotiator = new ForceTlsUpgradeNegotiation(
+            $connection,
+            'hostname',
+            CryptoConstant::getDefaultMethod(PHP_VERSION)
+        );
+        $negotiator->negotiate(new Client($connection));
+
+        $this->assertTrue($connection->getMetaData()['crypto']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_when_using_legacy_rfc821_and_starttls_not_supported()
+    {
+        $this->expectException(ConnectionInsecureException::class);
+
+        $connection = $this->createMock(ConnectionInterface::class);
+
+        $connection
+            ->expects($this->at(0))
+            ->method('addListener');
+
+        $connection
+            ->expects($this->at(1))
+            ->method('getMetaData')
+            ->willReturn([]);
+
+        $connection
+            ->expects($this->at(2))
+            ->method('send')
+            ->with("EHLO hostname\r\n")
+            ->willReturn(16);
+
+        $connection
+            ->expects($this->at(3))
+            ->method('receive')
+            ->willReturn("502 Not implemented\r\n");
+
+        $connection
+            ->expects($this->at(4))
+            ->method('send')
+            ->with("HELO hostname\r\n")
+            ->willReturn(16);
+
+        $connection
+            ->expects($this->at(5))
+            ->method('receive')
+            ->willReturn("220 Hello\r\n");
+
+        $connection
+            ->expects($this->at(6))
+            ->method('send')
+            ->with("STARTTLS\r\n")
+            ->willReturn(16);
+
+        $connection
+            ->expects($this->at(7))
+            ->method('receive')
+            ->willReturn("502 Not implemented\r\n");
+
+        $negotiator = new ForceTlsUpgradeNegotiation(
+            $connection,
+            'hostname',
+            CryptoConstant::getDefaultMethod(PHP_VERSION)
+        );
+        $negotiator->negotiate(new Client($connection));
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_upgrade_when_already_crypto()
+    {
+        $connection = $this->createMock(ConnectionInterface::class);
+
+        $connection
+            ->expects($this->at(0))
+            ->method('addListener');
+
+        $connection
+            ->expects($this->at(1))
+            ->method('getMetaData')
+            ->willReturn(['crypto' => []]);
 
         $negotiator = new ForceTlsUpgradeNegotiation(
             $connection,

--- a/test/Unit/Protocol/Smtp/Negotiation/TryTlsUpgradeNegotiationTest.php
+++ b/test/Unit/Protocol/Smtp/Negotiation/TryTlsUpgradeNegotiationTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Genkgo\TestMail\Unit\Protocol\Smtp\Negotiation;
 
+use Genkgo\Mail\Protocol\ConnectionInterface;
 use Genkgo\Mail\Protocol\CryptoConstant;
 use Genkgo\Mail\Protocol\Smtp\Client;
 use Genkgo\Mail\Protocol\Smtp\Negotiation\TryTlsUpgradeNegotiation;
@@ -48,4 +49,102 @@ final class TryTlsUpgradeNegotiationTest extends AbstractTestCase
         $this->assertArrayNotHasKey('crypto', $connection->getMetaData());
     }
 
+    /**
+     * @test
+     */
+    public function it_uses_legacy_rfc821_helo_when_ehlo_not_supported()
+    {
+        $connection = FakeSmtpConnection::newLegacyRfc821();
+        $connection->connect();
+
+        $negotiator = new TryTlsUpgradeNegotiation(
+            $connection,
+            'hostname',
+            CryptoConstant::getDefaultMethod(PHP_VERSION)
+        );
+        $negotiator->negotiate(new Client($connection));
+
+        $this->assertTrue($connection->getMetaData()['crypto']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_throw_when_using_legacy_rfc821_and_starttls_not_supported()
+    {
+        $connection = $this->createMock(ConnectionInterface::class);
+
+        $connection
+            ->expects($this->at(0))
+            ->method('addListener');
+
+        $connection
+            ->expects($this->at(1))
+            ->method('getMetaData')
+            ->willReturn([]);
+
+        $connection
+            ->expects($this->at(2))
+            ->method('send')
+            ->with("EHLO hostname\r\n")
+            ->willReturn(16);
+
+        $connection
+            ->expects($this->at(3))
+            ->method('receive')
+            ->willReturn("502 Not implemented\r\n");
+
+        $connection
+            ->expects($this->at(4))
+            ->method('send')
+            ->with("HELO hostname\r\n")
+            ->willReturn(16);
+
+        $connection
+            ->expects($this->at(5))
+            ->method('receive')
+            ->willReturn("220 Hello\r\n");
+
+        $connection
+            ->expects($this->at(6))
+            ->method('send')
+            ->with("STARTTLS\r\n")
+            ->willReturn(16);
+
+        $connection
+            ->expects($this->at(7))
+            ->method('receive')
+            ->willReturn("502 Not implemented\r\n");
+
+        $negotiator = new TryTlsUpgradeNegotiation(
+            $connection,
+            'hostname',
+            CryptoConstant::getDefaultMethod(PHP_VERSION)
+        );
+        $negotiator->negotiate(new Client($connection));
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_upgrade_when_already_crypto()
+    {
+        $connection = $this->createMock(ConnectionInterface::class);
+
+        $connection
+            ->expects($this->at(0))
+            ->method('addListener');
+
+        $connection
+            ->expects($this->at(1))
+            ->method('getMetaData')
+            ->willReturn(['crypto' => []]);
+
+        $negotiator = new TryTlsUpgradeNegotiation(
+            $connection,
+            'hostname',
+            CryptoConstant::getDefaultMethod(PHP_VERSION)
+        );
+        $negotiator->negotiate(new Client($connection));
+    }
 }

--- a/test/Unit/Protocol/Smtp/NullConnectionTest.php
+++ b/test/Unit/Protocol/Smtp/NullConnectionTest.php
@@ -61,6 +61,7 @@ class NullConnectionTest extends TestCase
 
     /**
      * @dataProvider providerSendReceive
+     * @test
      */
     public function it_responds_correctly_to_send_commands(string $send, string $expect): void
     {


### PR DESCRIPTION
When using a RFC 821 server, one cannot detect feature because they are not advertised with a HELO command. That 's why there is a EHLO command. That means that when negotiating `STARTTLS` one should not detect the feature but rather go for it anyhow.