### PR TITLE
Enhance QueueProcessor

### DIFF
--- a/src/Queue/QueueProcessor.php
+++ b/src/Queue/QueueProcessor.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Genkgo\Mail\Queue;
 
 use Genkgo\Mail\Exception\AbstractProtocolException;
-use Genkgo\Mail\Exception\ConnectionRefusedException;
 use Genkgo\Mail\Exception\EmptyQueueException;
 use Genkgo\Mail\TransportInterface;
 
@@ -28,7 +27,7 @@ final class QueueProcessor
      * @param TransportInterface $transport
      * @param QueueInterface[] $queue
      */
-    public function __construct(TransportInterface $transport, array $queue)
+    public function __construct(TransportInterface $transport, iterable $queue)
     {
         $this->transport = $transport;
         $this->queue = $queue;
@@ -37,8 +36,9 @@ final class QueueProcessor
     /**
      *
      */
-    public function process()
+    public function process(): int
     {
+        $count = 0;
         foreach ($this->queue as $queue) {
             try {
                 while ($message = $queue->fetch()) {
@@ -49,12 +49,14 @@ final class QueueProcessor
 
                         // do not continue transporting messages
                         // apparently our transport is not ready to receive messages yet
-                        return;
+                        return $count;
                     }
+                    ++$count;
                 }
             } catch (EmptyQueueException $e) {
             }
         }
-    }
 
+        return $count;
+    }
 }

--- a/test/Unit/Queue/ProcessorTest.php
+++ b/test/Unit/Queue/ProcessorTest.php
@@ -3,7 +3,6 @@
 namespace Genkgo\TestMail\Unit\Queue;
 
 use Genkgo\Mail\Exception\AbstractProtocolException;
-use Genkgo\TestMail\AbstractTestCase;;
 use Genkgo\Mail\Exception\ConnectionRefusedException;
 use Genkgo\Mail\GenericMessage;
 use Genkgo\Mail\Header\GenericHeader;
@@ -12,6 +11,7 @@ use Genkgo\Mail\Queue\ArrayObjectQueue;
 use Genkgo\Mail\Queue\QueueProcessor;
 use Genkgo\Mail\Stream\AsciiEncodedStream;
 use Genkgo\Mail\TransportInterface;
+use Genkgo\TestMail\AbstractTestCase;
 
 final class ProcessorTest extends AbstractTestCase
 {
@@ -51,7 +51,9 @@ final class ProcessorTest extends AbstractTestCase
             }));
 
         $processor = new QueueProcessor($transport, [$queue]);
-        $processor->process();
+        $count = $processor->process();
+
+        $this->assertSame(3, $count);
     }
 
     /**
@@ -77,9 +79,10 @@ final class ProcessorTest extends AbstractTestCase
         ;
 
         $processor = new QueueProcessor($transport, [$queue]);
-        $processor->process();
+        $count = $processor->process();
 
         $this->assertCount(3, $storage);
+        $this->assertSame(0, $count);
     }
 
     /**
@@ -105,9 +108,10 @@ final class ProcessorTest extends AbstractTestCase
         ;
 
         $processor = new QueueProcessor($transport, [$queue]);
-        $processor->process();
+        $count = $processor->process();
 
         $this->assertCount(3, $storage);
+        $this->assertSame(0, $count);
     }
 
     /**


### PR DESCRIPTION
- Accept iterable over array for queues
- Return the dispatched message count from process()

## Use Cases

- Count: Providing a small amount of visibility on internal processing and user feedback
- Type hint: When using DI such as Symfony's, it is possible to tag enabled/in-use queues, wrapping them in a `\Traversable` object