### PR TITLE
Let secure connection options create the stream context

### DIFF
--- a/src/Protocol/SecureConnection.php
+++ b/src/Protocol/SecureConnection.php
@@ -42,16 +42,12 @@ final class SecureConnection extends AbstractConnection
      */
     public function upgrade(int $type): void
     {
-        throw new \InvalidArgumentException('Cannot connection, already secure');
+        throw new \InvalidArgumentException('Cannot upgrade connection, already secure');
     }
     
     public function connect(): void
     {
-        $context = \stream_context_create([
-            'ssl' => [
-                'crypto_method' => $this->options->getMethod(),
-            ]
-        ]);
+        $context = $this->options->createContext();
 
         $resource = @\stream_socket_client(
             'tls://' . $this->host . ':' . $this->port,

--- a/src/Protocol/SecureConnectionOptions.php
+++ b/src/Protocol/SecureConnectionOptions.php
@@ -19,18 +19,27 @@ final class SecureConnectionOptions
     private $method;
 
     /**
-     * @param int $method
+     * @var array
      */
-    public function __construct(int $method)
+    private $contextOptions = [];
+
+    /**
+     * @param int $method
+     * @param int $timeout
+     * @param array $contextOptions
+     */
+    public function __construct(int $method, int $timeout = 10, array $contextOptions = [])
     {
         $this->method = $method;
+        $this->timeout = $timeout;
+        $this->contextOptions = $contextOptions;
     }
 
     /**
      * @param float $connectionTimeout
      * @return SecureConnectionOptions
      */
-    public function withTimeout(float $connectionTimeout): SecureConnectionOptions
+    public function withTimeout(float $connectionTimeout): self
     {
         $clone = clone $this;
         $clone->timeout = $connectionTimeout;
@@ -41,10 +50,21 @@ final class SecureConnectionOptions
      * @param int $method
      * @return SecureConnectionOptions
      */
-    public function withMethod(int $method): SecureConnectionOptions
+    public function withMethod(int $method): self
     {
         $clone = clone $this;
         $clone->method = $method;
+        return $clone;
+    }
+
+    /**
+     * @param array $contextOptions
+     * @return SecureConnectionOptions
+     */
+    public function withContextOptions(array $contextOptions): self
+    {
+        $clone = clone $this;
+        $clone->contextOptions = $contextOptions;
         return $clone;
     }
 
@@ -62,5 +82,26 @@ final class SecureConnectionOptions
     public function getMethod(): int
     {
         return $this->method;
+    }
+
+    /**
+     * @return array
+     */
+    public function getContextOptions(): array
+    {
+        return $this->contextOptions;
+    }
+
+    /**
+     * @return resource
+     */
+    public function createContext()
+    {
+        return \stream_context_create([
+            'ssl' => \array_merge(
+                $this->contextOptions,
+                ['crypto_method' => $this->method]
+            )
+        ]);
     }
 }


### PR DESCRIPTION
- let the secure connection options create the stream context
- add the possibility to extend the stream context options in SecureConnectionOptions
- fixes #19