### PR TITLE
do not encode the from header twice

### DIFF
--- a/src/Header/From.php
+++ b/src/Header/From.php
@@ -35,7 +35,7 @@ final class From implements HeaderInterface
      */
     public function getValue(): HeaderValue
     {
-        return new HeaderValue((string)$this->from);
+        return HeaderValue::fromEncodedString((string)$this->from);
     }
 
     /**

--- a/test/Unit/Header/FromTest.php
+++ b/test/Unit/Header/FromTest.php
@@ -50,4 +50,22 @@ final class FromTest extends AbstractTestCase
         $header = From::fromEmailAddress('me@example.com');
         $this->assertEquals('me@example.com', (string)$header->getValue());
     }
+
+    /**
+     * @test
+     */
+    public function it_uses_correct_encoding_with_long_names()
+    {
+        $from = new From(
+            new Address(
+                new EmailAddress('webmaster@xyz.domain.com'),
+                'Webmaster Organization Name With a Very Long Name Somewhere-Somehwere'
+            )
+        );
+
+        $this->assertEquals(
+            "Webmaster Organization Name With a Very Long Name\r\n Somewhere-Somehwere <webmaster@xyz.domain.com>",
+            (string)$from->getValue()
+        );
+    }
 }


### PR DESCRIPTION
The From header was encoded twice. This causes troubles especially when the address contains new lines due to character limits on a single line.