### PR TITLE
Enable UTF-8 when checking string is single line

### DIFF
--- a/src/Address.php
+++ b/src/Address.php
@@ -31,7 +31,7 @@ final class Address
      */
     public function __construct(EmailAddress $address, string $name = '')
     {
-        if (\preg_match('/\v/', $name) !== 0) {
+        if (\preg_match('/\v/u', $name) !== 0) {
             throw new \InvalidArgumentException('Cannot use vertical white space within name of email address');
         }
 

--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -25,7 +25,7 @@ final class EmailAddress
      */
     public function __construct(string $address)
     {
-        if (\preg_match('/\v/', $address, $matches) !== 0) {
+        if (\preg_match('/\v/u', $address, $matches) !== 0) {
             throw new \InvalidArgumentException('Cannot use vertical white space within email address');
         }
 

--- a/src/Header/Subject.php
+++ b/src/Header/Subject.php
@@ -17,7 +17,7 @@ final class Subject implements HeaderInterface
      */
     public function __construct(string $subject)
     {
-        if (\preg_match('/\v/', $subject) !== 0) {
+        if (\preg_match('/\v/u', $subject) !== 0) {
             throw new \InvalidArgumentException('Cannot use vertical white space within subject');
         }
 

--- a/test/Unit/AddressTest.php
+++ b/test/Unit/AddressTest.php
@@ -121,6 +121,15 @@ final class AddressTest extends AbstractTestCase
     }
 
     /**
+     * @test
+     */
+    public function it_can_be_constructed_with_a_multi_byte_name_leading_to_new_line_in_single_byte()
+    {
+        $address = new Address(new EmailAddress('local@domain.com'), 'Миха');
+        $this->assertEquals('=?UTF-8?B?0JzQuNGF0LA=?= <local@domain.com>', (string)$address);
+    }
+
+    /**
      * @return array
      */
     public function provideAddressStrings()

--- a/test/Unit/EmailAddressTest.php
+++ b/test/Unit/EmailAddressTest.php
@@ -51,6 +51,15 @@ final class EmailAddressTest extends AbstractTestCase
     /**
      * @test
      */
+    public function it_can_be_constructed_with_a_multi_byte_name_leading_to_new_line_in_single_byte()
+    {
+        $address = new EmailAddress('Миха@domain.com');
+        $this->assertEquals('Миха@domain.com', (string)$address);
+    }
+
+    /**
+     * @test
+     */
     public function it_is_equal_when_it_has_same_value()
     {
         $address = new EmailAddress('me@example.com');

--- a/test/Unit/Header/BccTest.php
+++ b/test/Unit/Header/BccTest.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 declare(strict_types=1);
 
 namespace Genkgo\TestMail\Unit\Header;

--- a/test/Unit/Header/GenericHeaderTest.php
+++ b/test/Unit/Header/GenericHeaderTest.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 declare(strict_types=1);
 
 namespace Genkgo\TestMail\Unit\Header;

--- a/test/Unit/Header/ParsedHeaderTest.php
+++ b/test/Unit/Header/ParsedHeaderTest.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 declare(strict_types=1);
 
 namespace Genkgo\TestMail\Unit\Header;

--- a/test/Unit/Header/SubjectTest.php
+++ b/test/Unit/Header/SubjectTest.php
@@ -25,6 +25,15 @@ final class SubjectTest extends AbstractTestCase
     }
 
     /**
+     * @test
+     */
+    public function it_can_be_constructed_with_a_multi_byte_name_leading_to_new_line_in_single_byte()
+    {
+        $subject = new Subject('Миха');
+        $this->assertEquals('=?UTF-8?B?0JzQuNGF0LA=?=', (string)$subject->getValue());
+    }
+
+    /**
      * @return array
      */
     public function provideValues()


### PR DESCRIPTION
Some multi-byte strings have a new line when interpreted as single byte.