### PR TITLE
only add Re: when needed in a reply message

### DIFF
--- a/src/MessageBodyCollection.php
+++ b/src/MessageBodyCollection.php
@@ -265,9 +265,15 @@ final class MessageBodyCollection
      */
     public function asForwardTo(MessageInterface $originalMessage): MessageInterface
     {
+        $extractedSubject = $this->extractSubject($originalMessage);
+
         return $this
             ->createReferencedMessage($originalMessage)
-            ->withHeader(new Subject('Fwd: ' . $this->extractSubject($originalMessage)));
+            ->withHeader(
+                new Subject(
+                    \substr($extractedSubject, 0, 4) === 'Fwd:' ? $extractedSubject : 'Fwd: ' . $extractedSubject
+                )
+            );
     }
 
     /**

--- a/src/MessageBodyCollection.php
+++ b/src/MessageBodyCollection.php
@@ -240,9 +240,15 @@ final class MessageBodyCollection
      */
     private function newReply(MessageInterface $originalMessage, array $replyRecipientHeaderNames): MessageInterface
     {
+        $extractedSubject = $this->extractSubject($originalMessage);
+
         $reply = $this
             ->createReferencedMessage($originalMessage)
-            ->withHeader(new Subject('Re: ' . $this->extractSubject($originalMessage)));
+            ->withHeader(
+                new Subject(
+                    \substr($extractedSubject, 0, 3) === 'Re:' ? $extractedSubject : 'Re: ' . $extractedSubject
+                )
+            );
 
         foreach ($replyRecipientHeaderNames as $replyRecipientHeaderName) {
             foreach ($originalMessage->getHeader($replyRecipientHeaderName) as $recipientHeader) {

--- a/test/Unit/MessageBodyCollectionTest.php
+++ b/test/Unit/MessageBodyCollectionTest.php
@@ -459,17 +459,38 @@ final class MessageBodyCollectionTest extends AbstractTestCase
     public function it_creates_reply_headers(): void
     {
         $messageId = MessageId::newRandom('domain');
+        $subject = new Subject('Some Value');
 
         $message = (new GenericMessage())
-            ->withHeader($messageId);
+            ->withHeader($messageId)
+            ->withHeader($subject);
 
         $body = new MessageBodyCollection();
         $reply = $body->inReplyTo($message);
 
         $this->assertTrue($reply->hasHeader('In-Reply-To'));
         $this->assertTrue($reply->hasHeader('References'));
+        $this->assertTrue($reply->hasHeader('Subject'));
         $this->assertSame((string)$messageId->getValue(), (string)$reply->getHeader('References')[0]->getValue());
         $this->assertSame((string)$messageId->getValue(), (string)$reply->getHeader('In-Reply-To')[0]->getValue());
+        $this->assertSame('Re: Some Value', (string)$reply->getHeader('Subject')[0]->getValue());
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_re_to_subject_only_when_needed(): void
+    {
+        $subject = new Subject('Re: Some Value');
+
+        $message = (new GenericMessage())
+            ->withHeader($subject);
+
+        $body = new MessageBodyCollection();
+        $reply = $body->inReplyTo($message);
+
+        $this->assertTrue($reply->hasHeader('Subject'));
+        $this->assertSame('Re: Some Value', (string)$reply->getHeader('Subject')[0]->getValue());
     }
 
     /**

--- a/test/Unit/MessageBodyCollectionTest.php
+++ b/test/Unit/MessageBodyCollectionTest.php
@@ -496,6 +496,40 @@ final class MessageBodyCollectionTest extends AbstractTestCase
     /**
      * @test
      */
+    public function it_adds_fwd_to_subject(): void
+    {
+        $subject = new Subject('Some Value');
+
+        $message = (new GenericMessage())
+            ->withHeader($subject);
+
+        $body = new MessageBodyCollection();
+        $forwarded = $body->asForwardTo($message);
+
+        $this->assertTrue($forwarded->hasHeader('Subject'));
+        $this->assertSame('Fwd: Some Value', (string)$forwarded->getHeader('Subject')[0]->getValue());
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_fwd_to_subject_only_when_needed(): void
+    {
+        $subject = new Subject('Fwd: Some Value');
+
+        $message = (new GenericMessage())
+            ->withHeader($subject);
+
+        $body = new MessageBodyCollection();
+        $forwarded = $body->asForwardTo($message);
+
+        $this->assertTrue($forwarded->hasHeader('Subject'));
+        $this->assertSame('Fwd: Some Value', (string)$forwarded->getHeader('Subject')[0]->getValue());
+    }
+
+    /**
+     * @test
+     */
     public function it_adds_reference(): void
     {
         $messageId = MessageId::newRandom('domain');


### PR DESCRIPTION
Only add Re: when replying to a message that does not contain Re: in the subject