### PR TITLE
Adapt AddressList.php::getIterator to suppress deprecation warning

### DIFF
--- a/src/AddressList.php
+++ b/src/AddressList.php
@@ -93,6 +93,7 @@ final class AddressList implements \Countable, \IteratorAggregate
     /**
      * @return \ArrayIterator<int, Address>
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->addresses);


### PR DESCRIPTION
I am using this library in a PHP **8.1** project. When running PHPUnit, it shows the following deprecation message:

> Deprecated: Return type of Genkgo\Mail\AddressList::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/vendor/genkgo/mail/src/AddressList.php on line 96

This fix should get rid of this message without introducing a breaking change.