### PR TITLE
EmailAddress should implement Stringable interface

### DIFF
--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 namespace Genkgo\Mail;
+use Stringable;
 
-final class EmailAddress
+final class EmailAddress implements Stringable
 {
     /**
      * @var string

--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -2,9 +2,8 @@
 declare(strict_types=1);
 
 namespace Genkgo\Mail;
-use Stringable;
 
-final class EmailAddress implements Stringable
+final class EmailAddress implements \Stringable
 {
     /**
      * @var string


### PR DESCRIPTION
It would ease the usage of `EmailAddress` even more, especially because there is already a `__toString` method implemented.

What do you think?