### PR TITLE
Update return type annotations for EmailAddress methods

### DIFF
--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -5,24 +5,12 @@ namespace Genkgo\Mail;
 
 final class EmailAddress implements \Stringable
 {
-    /**
-     * @var string
-     */
-    private $address;
+    private string $address;
 
-    /**
-     * @var string
-     */
-    private $localPart;
+    private string $localPart;
 
-    /**
-     * @var string
-     */
-    private $domain;
+    private string $domain;
 
-    /**
-     * @param string $address
-     */
     public function __construct(string $address)
     {
         if (\preg_match('/\v/u', $address, $matches) !== 0) {

--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -5,10 +5,19 @@ namespace Genkgo\Mail;
 
 final class EmailAddress implements \Stringable
 {
+    /**
+     * @var non-empty-string
+     */
     private string $address;
 
+    /**
+     * @var non-empty-string
+     */
     private string $localPart;
 
+    /**
+     * @var non-empty-string
+     */
     private string $domain;
 
     public function __construct(string $address)

--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -41,7 +41,7 @@ final class EmailAddress implements \Stringable
     }
 
     /**
-     * @return string
+     * @return non-empty-string
      */
     public function getAddress(): string
     {
@@ -49,7 +49,7 @@ final class EmailAddress implements \Stringable
     }
 
     /**
-     * @return string
+     * @return non-empty-string
      */
     public function getLocalPart(): string
     {
@@ -57,7 +57,7 @@ final class EmailAddress implements \Stringable
     }
 
     /**
-     * @return string
+     * @return non-empty-string
      */
     public function getDomain(): string
     {
@@ -98,7 +98,7 @@ final class EmailAddress implements \Stringable
     }
 
     /**
-     * @return string
+     * @return non-empty-string
      */
     public function __toString(): string
     {


### PR DESCRIPTION
Judging by the regex in the constructor of the `EmailAddress` class it only saves non-empty strings.

```php
$hits = \preg_match('/^([^@]+)@([^@]+)$/', $address, $matches);
if ($hits === 0) {
    throw new \InvalidArgumentException('Invalid e-mail address: ' . $address);
}
```

After the check it is [already stated](https://github.com/k00ni/mail/blob/06023d747c28c44418b49a237e75b608b6620850/src/EmailAddress.php#L40) that all these 3 values are non-empty strings:

```php
/** @var array{0: non-empty-string, 1: non-empty-string, 2: non-empty-string} $matches */
[$this->address, $this->localPart, $this->domain] = $matches;
```

Therefore I adapted the return value of some methods to be more precise. 

This change would save me from additional checks on my side, because I can be sure the email address always is a non empty string. 